### PR TITLE
Add comprehensive GitHub Actions workflow for all targets

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,71 @@
+# GitHub Actions Workflow for ST7789 MicroPython Module
+
+This directory contains GitHub Actions workflow configurations for automatically building the ST7789 MicroPython module for various target platforms.
+
+## Workflow: `build.yml`
+
+The `build.yml` workflow automates the process of building MicroPython firmware with the ST7789 module for all supported targets.
+
+### Triggers
+
+The workflow runs on:
+- Any tag starting with `v` (e.g., `v1.0.0`)
+- Manual trigger via GitHub Actions UI
+
+Note: Regular pushes to the repository are handled by the `esp32.yml` workflow, which builds only ESP32 targets.
+
+### Jobs
+
+The workflow consists of the following jobs:
+
+1. **build-esp32-targets**: Builds firmware for ESP32-based targets
+   - Uses the official ESP-IDF v5.4 Docker image
+   - Builds for multiple ESP32 variants (GENERIC, GENERIC_SPIRAM, ESP32-C3, ESP32-S2, ESP32-S3, etc.)
+   - Includes specific board targets (M5CORE, T-DISPLAY, etc.)
+
+2. **build-rp2-targets**: Builds firmware for Raspberry Pi Pico (RP2040) targets
+   - Builds for RP2, RP2W, and T-DISPLAY-RP2040
+
+3. **build-stm32-targets**: Builds firmware for STM32-based targets
+   - Currently only builds for PYBV11 (Pyboard v1.1)
+
+4. **create-release**: Creates a GitHub release with firmware packages
+   - Only runs when a tag is pushed
+   - Creates a draft release with separate ZIP files for each target
+   - Includes README files with build information
+
+5. **build-all-in-one**: Creates a combined firmware package
+   - Collects all built firmware files
+   - Creates a single ZIP file with all targets
+
+### Artifacts
+
+Each job produces artifacts that are uploaded to GitHub:
+- Individual firmware files (.bin, .elf, .map, .uf2, .dfu)
+- Target-specific ZIP packages
+- All-in-one firmware package
+
+### Customization
+
+To customize the build process:
+1. Modify the target lists in the matrix configuration
+2. Adjust the frozen modules copied to the build
+3. Change build parameters as needed
+
+## Usage
+
+To use this workflow:
+
+1. Create a tag (e.g., `v1.0.0`) to trigger a build and release:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+2. Use the "Run workflow" button in the GitHub Actions UI for manual builds
+
+## Troubleshooting
+
+If a build fails:
+1. Check the job logs for specific error messages
+2. Verify that the target board is correctly defined in MicroPython
+3. Ensure the ESP-IDF version is compatible with the MicroPython version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,291 @@
+name: Build MicroPython ST7789 Module (All Targets)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+  # Only run this comprehensive workflow on tags and manual triggers
+  # The esp32.yml workflow handles regular pushes for ESP32 targets
+
+jobs:
+  build-esp32-targets:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:v5.4
+    env:
+      MICROPYTHON_VERSION: v1.25.0
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          "GENERIC-7789",
+          "GENERIC_SPIRAM-7789",
+          "GENERIC_C3",
+          "GENERIC_C3_USB",
+          "GENERIC_S2",
+          "GENERIC_S3_7789",
+          "GENERIC_S3_SPIRAM",
+          "GENERIC_S3_SPIRAM_OCT",
+          "LOLIN_S2_MINI",
+          "M5CORE",
+          "M5CORE2",
+          "T-DISPLAY-ESP32",
+          "T-DONGLE-S3",
+          "TWATCH-2020",
+          "ESP32_BOX_LITE"
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: st7789_mpy
+
+      - name: Checkout MicroPython
+        uses: actions/checkout@v3
+        with:
+          repository: micropython/micropython
+          path: micropython
+          ref: ${{ env.MICROPYTHON_VERSION }}
+          submodules: true
+
+      - name: Setup build environment
+        run: |
+          . $IDF_PATH/export.sh
+          cd micropython
+          make -C mpy-cross
+
+      - name: Build firmware for ${{ matrix.target }}
+        run: |
+          . $IDF_PATH/export.sh
+          cd micropython/ports/esp32
+          
+          # Create modules directory if it doesn't exist
+          mkdir -p modules
+          
+          # Copy some common font files as frozen modules (optional)
+          cp -f ../../../st7789_mpy/fonts/bitmap/vga1_16x16.py modules/ || true
+          cp -f ../../../st7789_mpy/fonts/bitmap/vga2_8x8.py modules/ || true
+          
+          # Build the firmware with the st7789 module
+          make USER_C_MODULES=../../../../st7789_mpy/micropython.cmake BOARD=${{ matrix.target }}
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}-firmware
+          path: |
+            micropython/ports/esp32/build-${{ matrix.target }}/firmware.bin
+            micropython/ports/esp32/build-${{ matrix.target }}/firmware.elf
+            micropython/ports/esp32/build-${{ matrix.target }}/firmware.map
+          retention-days: 7
+
+  build-rp2-targets:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:v5.4
+    env:
+      MICROPYTHON_VERSION: v1.25.0
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          "RP2",
+          "RP2W",
+          "T-DISPLAY-RP2040"
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: st7789_mpy
+
+      - name: Checkout MicroPython
+        uses: actions/checkout@v3
+        with:
+          repository: micropython/micropython
+          path: micropython
+          ref: ${{ env.MICROPYTHON_VERSION }}
+          submodules: true
+
+      - name: Install RP2 build dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+
+      - name: Setup build environment
+        run: |
+          cd micropython
+          make -C mpy-cross
+
+      - name: Build firmware for ${{ matrix.target }}
+        run: |
+          cd micropython/ports/rp2
+          
+          # Create modules directory if it doesn't exist
+          mkdir -p modules
+          
+          # Copy some common font files as frozen modules (optional)
+          cp -f ../../../st7789_mpy/fonts/bitmap/vga1_16x16.py modules/ || true
+          cp -f ../../../st7789_mpy/fonts/bitmap/vga2_8x8.py modules/ || true
+          
+          # Build the firmware with the st7789 module
+          make USER_C_MODULES=../../../st7789_mpy/micropython.cmake BOARD=${{ matrix.target }}
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}-firmware
+          path: |
+            micropython/ports/rp2/build-${{ matrix.target }}/firmware.uf2
+            micropython/ports/rp2/build-${{ matrix.target }}/firmware.elf
+            micropython/ports/rp2/build-${{ matrix.target }}/firmware.map
+          retention-days: 7
+
+  build-stm32-targets:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:v5.4
+    env:
+      MICROPYTHON_VERSION: v1.25.0
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          "PYBV11"
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: st7789_mpy
+
+      - name: Checkout MicroPython
+        uses: actions/checkout@v3
+        with:
+          repository: micropython/micropython
+          path: micropython
+          ref: ${{ env.MICROPYTHON_VERSION }}
+          submodules: true
+
+      - name: Install STM32 build dependencies
+        run: |
+          apt-get update
+          apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+
+      - name: Setup build environment
+        run: |
+          cd micropython
+          make -C mpy-cross
+
+      - name: Build firmware for ${{ matrix.target }}
+        run: |
+          cd micropython/ports/stm32
+          
+          # Create modules directory if it doesn't exist
+          mkdir -p modules
+          
+          # Copy some common font files as frozen modules (optional)
+          cp -f ../../../st7789_mpy/fonts/bitmap/vga1_16x16.py modules/ || true
+          cp -f ../../../st7789_mpy/fonts/bitmap/vga2_8x8.py modules/ || true
+          
+          # Build the firmware with the st7789 module
+          make USER_C_MODULES=../../../st7789_mpy/micropython.cmake BOARD=${{ matrix.target }}
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}-firmware
+          path: |
+            micropython/ports/stm32/build-${{ matrix.target }}/firmware.dfu
+            micropython/ports/stm32/build-${{ matrix.target }}/firmware.elf
+            micropython/ports/stm32/build-${{ matrix.target }}/firmware.map
+          retention-days: 7
+
+  create-release:
+    needs: [build-esp32-targets, build-rp2-targets, build-stm32-targets]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release_assets
+          
+          # Create directories for each target
+          for target_dir in artifacts/*-firmware; do
+            target=$(basename $target_dir -firmware)
+            mkdir -p release_assets/$target
+            
+            # Copy firmware files to target directory
+            cp -r $target_dir/* release_assets/$target/
+            
+            # Create a README file for each target
+            echo "# $target Firmware" > release_assets/$target/README.md
+            echo "Built from $(git rev-parse --short HEAD)" >> release_assets/$target/README.md
+            echo "Built on $(date)" >> release_assets/$target/README.md
+          done
+          
+          # Create a zip file for each target
+          cd release_assets
+          for target in */; do
+            target=${target%/}
+            zip -r $target.zip $target
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release_assets/*.zip
+          draft: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-all-in-one:
+    needs: [build-esp32-targets, build-rp2-targets, build-stm32-targets]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Create all-in-one firmware package
+        run: |
+          mkdir -p all_firmware
+          
+          # Copy all firmware files to a single directory
+          for target_dir in artifacts/*-firmware; do
+            target=$(basename $target_dir -firmware)
+            mkdir -p all_firmware/$target
+            cp -r $target_dir/* all_firmware/$target/
+          done
+          
+          # Create a README file
+          echo "# ST7789 MicroPython Module Firmware" > all_firmware/README.md
+          echo "Built on $(date)" >> all_firmware/README.md
+          echo "## Targets" >> all_firmware/README.md
+          for target in all_firmware/*/; do
+            target=${target%/}
+            target=$(basename $target)
+            echo "- $target" >> all_firmware/README.md
+          done
+          
+          # Create a zip file
+          cd all_firmware
+          zip -r ../st7789_mpy_all_firmware.zip *
+
+      - name: Upload all-in-one firmware artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: all-firmware-package
+          path: st7789_mpy_all_firmware.zip
+          retention-days: 7

--- a/docs/github_actions.md
+++ b/docs/github_actions.md
@@ -1,0 +1,106 @@
+# Using GitHub Actions to Build ST7789 MicroPython Module
+
+This document explains how to use the GitHub Actions workflow to automatically build the ST7789 MicroPython module for various target platforms.
+
+## Overview
+
+The GitHub Actions workflow automates the process of building MicroPython firmware with the ST7789 module integrated. It uses the ESP-IDF Docker image to ensure a consistent build environment and builds firmware for all supported targets.
+
+## Supported Targets
+
+The workflow builds firmware for the following targets:
+
+### ESP32-based Targets
+- GENERIC-7789
+- GENERIC_SPIRAM-7789
+- GENERIC_C3
+- GENERIC_C3_USB
+- GENERIC_S2
+- GENERIC_S3_7789
+- GENERIC_S3_SPIRAM
+- GENERIC_S3_SPIRAM_OCT
+- LOLIN_S2_MINI
+- M5CORE
+- M5CORE2
+- T-DISPLAY-ESP32
+- T-DONGLE-S3
+- TWATCH-2020
+- ESP32_BOX_LITE
+
+### Raspberry Pi Pico (RP2040) Targets
+- RP2
+- RP2W
+- T-DISPLAY-RP2040
+
+### STM32-based Targets
+- PYBV11 (Pyboard v1.1)
+
+## How the Workflow Works
+
+1. The workflow checks out both the ST7789 module repository and the MicroPython repository
+2. It sets up the build environment using the ESP-IDF Docker image
+3. For each target:
+   - It builds the MicroPython cross-compiler
+   - Optionally copies font files as frozen modules
+   - Builds the firmware with the ST7789 module integrated
+   - Uploads the resulting firmware files as artifacts
+4. If triggered by a tag, it creates a GitHub release with firmware packages
+5. It also creates an all-in-one firmware package containing all targets
+
+## Using the Built Firmware
+
+After the workflow completes, you can:
+
+1. Download the artifacts from the GitHub Actions run
+2. Flash the appropriate firmware to your device:
+   - For ESP32: Use `esptool.py` to flash the `.bin` file
+   - For RP2040: Copy the `.uf2` file to the RP2040 in bootloader mode
+   - For STM32: Use DFU tools to flash the `.dfu` file
+
+## Triggering the Workflow
+
+The workflow can be triggered in two ways:
+
+1. **Automatically on tag**: When you create a tag starting with `v` (e.g., `v1.0.0`)
+2. **Manually**: Using the "Run workflow" button in the GitHub Actions UI
+
+Note: Regular pushes to the repository are handled by the `esp32.yml` workflow, which builds only ESP32 targets.
+
+## Creating a Release
+
+To create a release with all firmware files:
+
+1. Create and push a tag starting with `v`:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+2. The workflow will automatically:
+   - Build all firmware targets
+   - Create a draft GitHub release
+   - Attach firmware packages to the release
+
+3. Review the draft release on GitHub and publish it when ready
+
+## Customizing the Build
+
+To customize the build process:
+
+1. Modify the `.github/workflows/build.yml` file:
+   - Add or remove targets from the matrix configuration
+   - Change the frozen modules included in the build
+   - Adjust build parameters
+
+2. Commit and push your changes to trigger a new build
+
+## Troubleshooting
+
+If you encounter issues with the build:
+
+1. Check the GitHub Actions logs for specific error messages
+2. Verify that your target board is correctly defined in MicroPython
+3. Ensure you're using a compatible ESP-IDF version
+4. Check that the ST7789 module code is compatible with the MicroPython version
+
+For more detailed information, refer to the README in the `.github/workflows` directory.


### PR DESCRIPTION
## Description

This PR adds a comprehensive GitHub Actions workflow to build MicroPython firmware with the ST7789 module for all supported targets (ESP32, RP2, STM32).

### Changes

- Add `build.yml` workflow to build firmware for all supported targets
- Configure workflow to run on tag creation and manual triggers
- Add release creation for tagged builds
- Add documentation for the GitHub Actions workflow in `.github/workflows/README.md`
- Add user documentation in `docs/github_actions.md`
- Ensure compatibility with existing `esp32.yml` workflow

### Benefits

- Automated builds for all supported targets
- Automated release creation when tagging versions
- Comprehensive documentation for users and contributors
- Simplified firmware distribution process

### Testing

The workflow can be tested by:
1. Creating a tag (e.g., `v1.0.0`) to trigger a build and release
2. Using the "Run workflow" button in the GitHub Actions UI for manual builds

### Notes

- The workflow uses ESP-IDF v5.4 and MicroPython v1.25.0 to match the existing workflow
- Regular pushes to the repository are still handled by the existing `esp32.yml` workflow